### PR TITLE
fix: rename readme name in other ci to lowercase

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,9 @@
 name: Lint Awesome List
-on: [pull_request, push]
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   awesome-lint:

--- a/ci/.circleci/config.yml
+++ b/ci/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: gem install awesome_bot
-      - run: awesome_bot README.md --allow-redirect --allow-dupe
+      - run: awesome_bot readme.md --allow-redirect --allow-dupe
   'awesome-lint':
     docker:
       - image: circleci/node:lts
@@ -28,4 +28,4 @@ workflows:
   build:
     jobs:
       - 'awesome-lint'
-- 'awesome-bot'
+      - 'awesome-bot'

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -16,4 +16,4 @@ awesome-bot:
   image: ruby:latest
   script:
     - gem install awesome_bot
-    - awesome_bot README.md --allow-redirect --allow-dupe
+    - awesome_bot readme.md --allow-redirect --allow-dupe

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ This is an [awesome-list](https://github.com/sindresorhus/awesome) template with
 4. edit `contributing.md`
    - update `TODO_YOUR_REPO_NAME_HERE`
 5. choose a CI template
-   - github action: move config folver from `repo-root/ci/.github/` to `repo-root/.github`
-   - circle ci: move config folder from `repo-root/ci/.circleci/*` to `repo-root/.circleci/*`
-   - gitlab ci: move config file from `repo-root/ci/.gitlab-ci.yml` to the `repo-root/.gitlab-ci.yml`
+   - GitHub Action: move config folver from `repo-root/ci/.github/` to `repo-root/.github`
+   - Circle CI: move config folder from `repo-root/ci/.circleci/*` to `repo-root/.circleci/*`
+   - GitLab CI: move config file from `repo-root/ci/.gitlab-ci.yml` to the `repo-root/.gitlab-ci.yml`
 6. delete this file
 7. rename `readme-template.md` file to `readme.md`
 8. if using GitHub Actions, rename `readme-template.md` to `readme.md` in the GitHub Workflow file `.github/workflows/lint.yaml`

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ This is an [awesome-list](https://github.com/sindresorhus/awesome) template with
    - gitlab ci: move config file from `repo-root/ci/.gitlab-ci.yml` to the `repo-root/.gitlab-ci.yml`
 6. delete this file
 7. rename `readme-template.md` file to `readme.md`
-8. rename `readme-template.md` to `readme.md` in the GitHub Workflow file `.github/workflows/lint.yaml`
+8. if using GitHub Actions, rename `readme-template.md` to `readme.md` in the GitHub Workflow file `.github/workflows/lint.yaml`
 
 ## Contributing
 


### PR DESCRIPTION
- [x] fix GitHub Actions so the events are only run once, PRs on PR and push on push to main branch
- [x] fix capitalisation of `readme.md` in non-GitHub Actions CI specs
- [x] fix malformed `yaml` for CircleCI
- [x] clearer step 8 