### PR TITLE
ci: lint with npx

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,16 +1,21 @@
-name: Lint Awesome List
-on: [pull_request, push]
+name: lint
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   awesome-lint:
-    name: "lint: awesome-lint"
     runs-on: ubuntu-latest
     steps:
       - name: "checkout repo"
         uses: actions/checkout@v2.0.0
         with:
           fetch-depth: 0
-      - name: "lint: awesome-lint"
-        uses: jthegedus/github-action-awesome-lint@v0.1.0 # I trust me, so will happily use Tag versioning over commit_sha
+      - name: "setup node"
+        uses: actions/setup-node@v2
         with:
-          args: ./readme-template.md
+          node-version: '16'
+      - name: "awesome-lint"
+        run: npx -y awesome-lint ./readme-template.md


### PR DESCRIPTION
`jthegedus/github-action-awesome-lint` was deprecated. Use `npx` instead.